### PR TITLE
Make the module use it's own tranlation file

### DIFF
--- a/app/code/community/Jbh/ConnectAs/etc/config.xml
+++ b/app/code/community/Jbh/ConnectAs/etc/config.xml
@@ -49,5 +49,14 @@
                 </observers>
             </controller_action_layout_render_before_adminhtml_customer_edit>
         </events>
+        <translate>
+            <modules>
+                <connectas>
+                    <files>
+                        <default>Jbh_ConnectAs.csv</default>
+                    </files>
+                </connectas>
+            </modules>
+        </translate>
     </adminhtml>
 </config>


### PR DESCRIPTION
Instead of using the global Mage_Adminhtml.csv
